### PR TITLE
add Flocker specific options in Makefile and Flocker template file

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -1,28 +1,54 @@
 NUM_REPLICAS=$(shell kubectl get rc -l role=mongo -o template --template='{{ len .items }}')
 NEW_REPLICA_NUM=$(shell expr $(NUM_REPLICAS) + 1 )
+CREATE_SERVICE=TRUE
 
-ZONE=us-central1-f
 
-DISK_SIZE=500GB
-
+# ENV Options
+# -GoogleCloudPlatform
+# -FLOCKERAWS
+# -AWS (NOT YET SUPPORTED)
 ENV=GoogleCloudPlatform
 
-CREATE_SERVICE=TRUE
+# Default volume size on creation
+DISK_SIZE=100GB
+
+# GoogleCloudPlatform Specific Environment Variables
+ZONE=us-central1-f
+
+# FLOCKERAWS Specific Environment Variables
+CONTROL_DNS=<FLOCKER CONTROL DNS>
+INITIAL_NODE_ID=<A FLOCKER NODE ID TO SEED A VOLUME>
+VOLUME_PREFIX=<any name to prefix your volumes with>
+KUBECONFIG=clusters/<K8s Cluster Name>/kubeconfig
+
 
 count:
 	@echo 'Current Number of MongoDB Replicas: $(NUM_REPLICAS)'
-
+create-volume:
+ifeq ($(ENV),FLOCKERAWS)
+	-flockerctl --control-service=$(CONTROL_DNS) create -m name=$(VOLUME_PREFIX)-$(NEW_REPLICA_NUM) -s $(DISK_SIZE) --node=$(INITIAL_NODE_ID)
+endif
 add-replica:
 ifeq ($(ENV),GoogleCloudPlatform)
 	@echo 'Creating Disk'
 	-gcloud compute disks create mongo-persistent-storage-node-$(NEW_REPLICA_NUM)-disk --size $(DISK_SIZE) --zone $(ZONE)
-	
+
 	@echo 'Adding Replica'
 	-sed -e 's~<num>~$(NEW_REPLICA_NUM)~g' mongo-controller-template.yaml | kubectl create -f -
-	
 endif
 ifeq ($(ENV),AWS)
 	@echo 'AWS not supported yet'
+endif
+ifeq ($(ENV),FLOCKERAWS)
+	@echo 'Adding Replica $(NEW_REPLICA_NUM)'
+
+	-touch mongo-rc-$(NEW_REPLICA_NUM).yaml
+	# replace volume name with declared $(VOLUME_PREFIX) and $(NEW_REPLICA_NUM)
+	# This will create a new file allowing you to remove and redeploy specific Replication Controllers
+	# kubectl create -f mongo-rc-1.yaml
+	# kubectl delete -f mongo-rc-1.yaml
+	-sed -e 's/<num>/$(NEW_REPLICA_NUM)/g' -e 's/VOLUME_PREFIX/$(VOLUME_PREFIX)/g' mongo-controller-flocker-template.yaml | tee mongo-rc-$(NEW_REPLICA_NUM).yaml
+	-kubectl create -f mongo-rc-$(NEW_REPLICA_NUM).yaml
 endif
 ifeq ($(CREATE_SERVICE),TRUE)
 	@echo 'Creating Service'
@@ -35,7 +61,7 @@ delete-replica:
 ifeq ($(ENV),GoogleCloudPlatform)
 	@echo 'Deleting Replic'
 	-kubectl delete rc mongo-$(NUM_REPLICAS)
-	
+
 	@echo 'Deleting Disk'
 	sleep 60
 	-yes | gcloud compute disks delete mongo-persistent-storage-node-$(NUM_REPLICAS)-disk --zone $(ZONE)

--- a/example/emptydir_pod_examples/mongo-rc-emptydir-1.yaml
+++ b/example/emptydir_pod_examples/mongo-rc-emptydir-1.yaml
@@ -1,0 +1,52 @@
+#	Copyright 2016, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: mongo-1
+spec:
+  replicas: 1
+  selector:
+    name: mongo-node-1
+    role: mongo
+    environment: test
+  template:
+    spec:
+      containers:
+        - name: mongo-node-1
+          image: mongo
+          command:
+            - mongod
+            - "--replSet"
+            - rs0
+            - "--smallfiles"
+            - "--noprealloc"
+          ports:
+            - containerPort: 27017
+              hostPort: 4000
+          volumeMounts:
+            - name: mongo-persistent-storage
+              mountPath: /data/db
+        - name: mongo-sidecar
+          image: leportlabs/mongo-k8s-sidecar
+          env:
+            - name: MONGO_SIDECAR_POD_LABELS
+              value: "role=mongo,environment=test"
+      volumes:
+        - name: mongo-persistent-storage
+          emptyDir: {}
+    metadata:
+      labels:
+        name: mongo-node-1
+        role: mongo
+        environment: test

--- a/example/emptydir_pod_examples/mongo-rc-emptydir-2.yaml
+++ b/example/emptydir_pod_examples/mongo-rc-emptydir-2.yaml
@@ -1,0 +1,52 @@
+#	Copyright 2016, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: mongo-2
+spec:
+  replicas: 1
+  selector:
+    name: mongo-node-2
+    role: mongo
+    environment: test
+  template:
+    spec:
+      containers:
+        - name: mongo-node-2
+          image: mongo
+          command:
+            - mongod
+            - "--replSet"
+            - rs0
+            - "--smallfiles"
+            - "--noprealloc"
+          ports:
+            - containerPort: 27017
+              hostPort: 4000
+          volumeMounts:
+            - name: mongo-persistent-storage
+              mountPath: /data/db
+        - name: mongo-sidecar
+          image: leportlabs/mongo-k8s-sidecar
+          env:
+            - name: MONGO_SIDECAR_POD_LABELS
+              value: "role=mongo,environment=test"
+      volumes:
+        - name: mongo-persistent-storage
+          emptyDir: {}
+    metadata:
+      labels:
+        name: mongo-node-2
+        role: mongo
+        environment: test

--- a/example/emptydir_pod_examples/mongo-rc-emptydir-3.yaml
+++ b/example/emptydir_pod_examples/mongo-rc-emptydir-3.yaml
@@ -1,0 +1,53 @@
+#	Copyright 2016, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: mongo-3
+spec:
+  replicas: 1
+  selector:
+    name: mongo-node-3
+    role: mongo
+    environment: test
+  template:
+    spec:
+      containers:
+        - name: mongo-node-3
+          image: mongo
+          command:
+            - mongod
+            - "--replSet"
+            - rs0
+            - "--smallfiles"
+            - "--noprealloc"
+          ports:
+            - containerPort: 27017
+              hostPort: 4000
+          volumeMounts:
+            - name: mongo-persistent-storage
+              mountPath: /data/db
+        - name: mongo-sidecar
+          image: leportlabs/mongo-k8s-sidecar
+          env:
+            - name: MONGO_SIDECAR_POD_LABELS
+              value: "role=mongo,environment=test"
+      volumes:
+        - name: mongo-persistent-storage
+          emptyDir: {}
+    metadata:
+      labels:
+        name: mongo-node-3
+        role: mongo
+        environment: test
+

--- a/example/emptydir_pod_examples/mongo-rc-emptydir-4.yaml
+++ b/example/emptydir_pod_examples/mongo-rc-emptydir-4.yaml
@@ -1,0 +1,54 @@
+#	Copyright 2016, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: mongo-4
+spec:
+  replicas: 1
+  selector:
+    name: mongo-node-4
+    role: mongo
+    environment: test
+  template:
+    spec:
+      containers:
+        - name: mongo-node-4
+          image: mongo
+          command:
+            - mongod
+            - "--replSet"
+            - rs0
+            - "--smallfiles"
+            - "--noprealloc"
+          ports:
+            - containerPort: 27017
+          volumeMounts:
+            - name: mongo-persistent-storage
+              mountPath: /data/db
+        - name: mongo-sidecar
+          image: leportlabs/mongo-k8s-sidecar
+          env:
+            - name: MONGO_SIDECAR_POD_LABELS
+              value: "role=mongo,environment=test"
+      volumes:
+        - name: mongo-persistent-storage
+          flocker:
+            datasetName: flockermongorc-4
+      nodeSelector:
+        node: "2"
+    metadata:
+      labels:
+        name: mongo-node-4
+        role: mongo
+        environment: test

--- a/example/mongo-controller-flocker-template.yaml
+++ b/example/mongo-controller-flocker-template.yaml
@@ -1,0 +1,53 @@
+#	Copyright 2016, Google, Inc.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+kind: ReplicationController
+apiVersion: v1
+metadata:
+  name: mongo-<num>
+spec:
+  replicas: 1
+  selector:
+    name: mongo-node-<num>
+    role: mongo
+    environment: test
+  template:
+    spec:
+      containers:
+        - name: mongo-node-<num>
+          image: mongo
+          command:
+            - mongod
+            - "--replSet"
+            - rs0
+            - "--smallfiles"
+            - "--noprealloc"
+          ports:
+            - containerPort: 27017
+              hostPort: 4000
+          volumeMounts:
+            - name: mongo-persistent-storage
+              mountPath: /data/db
+        - name: mongo-sidecar
+          image: leportlabs/mongo-k8s-sidecar
+          env:
+            - name: MONGO_SIDECAR_POD_LABELS
+              value: "role=mongo,environment=test"
+      volumes:
+        - name: mongo-persistent-storage
+          flocker:
+            datasetName: VOLUME_PREFIX-<num>
+    metadata:
+      labels:
+        name: mongo-node-<num>
+        role: mongo
+        environment: test


### PR DESCRIPTION
Edits/organized to Makefile for Flocker volumes
Added Flocker specific template

the template includes a `hostPort: 4000` hack that allows a replication to ensure that it is deployed on a separate node where no other replica is running.
